### PR TITLE
Perf keep one line only

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"regexp"
-	"slices"
 
 	"github.com/iancoleman/strcase"
 	"github.com/sjiekak/logen"
@@ -66,12 +65,13 @@ func logmatch(r io.Reader) (state, error) {
 				matched = true
 
 				matchGroups[j].occurrences = append(matchGroups[j].occurrences, i)
+				moveToCorrectRank(matchGroups, j)
 
 				// sort when out of order
 				// could also find desired location and swap but lazy
-				if j != 0 && len(matchGroups[j-1].occurrences) < len(matchGroups[j].occurrences) {
+				/*if j != 0 && len(matchGroups[j-1].occurrences) < len(matchGroups[j].occurrences) {
 					slices.SortFunc(matchGroups, matchRank)
-				}
+				}*/
 
 				break
 			}
@@ -91,6 +91,21 @@ func logmatch(r io.Reader) (state, error) {
 		sanitizedLines: sanitizedLines,
 		classes:        matchGroups,
 	}, nil
+}
+
+// move the element at index in its correct position in the sorted match group list
+// works only because the index is already >= index + n
+func moveToCorrectRank(matchGroups []Match, index int) {
+	j := index - 1
+	for j >= 0 && len(matchGroups[j].occurrences) < len(matchGroups[index].occurrences) {
+		j--
+	}
+
+	j++
+	if j == index {
+		return
+	}
+	matchGroups[j], matchGroups[index] = matchGroups[index], matchGroups[j]
 }
 
 type state struct {

--- a/main_test.go
+++ b/main_test.go
@@ -55,10 +55,10 @@ func Test_Logmatch(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			r := makeText(tc.carrots, tc.sellers, tc.weird)
-			state, err := logmatch(r)
+			matchGroups, err := logmatch(r)
 			require.NoError(t, err)
 
-			assert.Len(t, state.classes, tc.expectedGroups)
+			assert.Len(t, matchGroups, tc.expectedGroups)
 
 		})
 	}


### PR DESCRIPTION
benchmark : 

```
Benchmark_Logmatch-16                  3         393415746 ns/op        160226032 B/op    929744 allocs/op <-- main
Benchmark_Logmatch-16                  3         379557086 ns/op        159864770 B/op    929729 allocs/op <-- not sorting
Benchmark_Logmatch-16    	           3	     386230985 ns/op	    160252378 B/op	  929739 allocs/op <-- not storing lines
```

to be honest, do not change much :P.

Still, now an arbitrary number of lines can be processed